### PR TITLE
make ValueArg and MultiArg legal with g++11 c++20

### DIFF
--- a/include/tclap/MultiArg.h
+++ b/include/tclap/MultiArg.h
@@ -228,7 +228,7 @@ private:
 	/**
 	 * Prevent accidental copying
 	 */
-	MultiArg<T>(const MultiArg<T>& rhs);
+	MultiArg(const MultiArg<T>& rhs);
 	MultiArg<T>& operator=(const MultiArg<T>& rhs);
 
 };

--- a/include/tclap/ValueArg.h
+++ b/include/tclap/ValueArg.h
@@ -253,7 +253,7 @@ private:
   /**
    * Prevent accidental copying
    */
-  ValueArg<T>(const ValueArg<T>& rhs);
+  ValueArg(const ValueArg<T>& rhs);
   ValueArg<T>& operator=(const ValueArg<T>& rhs);
 };
 


### PR DESCRIPTION
Without this change, gcc 11.1.0 with c++20 selected returns "unqualified name expected before const". I think the existing code is not standard-legal but widely accepted, at least until c++20.
